### PR TITLE
Deduplicate service names in billing report

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -43,12 +43,13 @@ def get_services():
     response = client.list_metrics(
         Namespace="AWS/Billing", MetricName="EstimatedCharges"
     )
-    services = []
-    for r in response["Metrics"]:
-        for d in r["Dimensions"]:
-            if d["Name"] == "ServiceName":
-                services.append(d["Value"])
-    return services
+    services = dict.fromkeys(
+        d["Value"]
+        for r in response["Metrics"]
+        for d in r["Dimensions"]
+        if d["Name"] == "ServiceName"
+    )
+    return list(services)
 
 
 def get_billings():

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -27,6 +27,41 @@ class NotifierTest(unittest.TestCase):
             expected_message_payload_without_datapoints_content,
         )
 
+    def test_get_services_deduplicates(self):
+        duplicated_services_json = {
+            "Metrics": [
+                {
+                    "Namespace": "AWS/Billing",
+                    "MetricName": "EstimatedCharges",
+                    "Dimensions": [
+                        {"Name": "ServiceName", "Value": "AmazonEC2"},
+                        {"Name": "Currency", "Value": "USD"},
+                    ],
+                },
+                {
+                    "Namespace": "AWS/Billing",
+                    "MetricName": "EstimatedCharges",
+                    "Dimensions": [
+                        {"Name": "ServiceName", "Value": "AmazonEC2"},
+                        {"Name": "LinkedAccount", "Value": "123456789"},
+                        {"Name": "Currency", "Value": "USD"},
+                    ],
+                },
+                {
+                    "Namespace": "AWS/Billing",
+                    "MetricName": "EstimatedCharges",
+                    "Dimensions": [
+                        {"Name": "ServiceName", "Value": "AmazonS3"},
+                        {"Name": "Currency", "Value": "USD"},
+                    ],
+                },
+            ],
+            "ResponseMetadata": {"RequestId": "test", "HTTPStatusCode": 200, "HTTPHeaders": {}, "RetryAttempts": 0},
+        }
+        handler.client.list_metrics = MagicMock(return_value=duplicated_services_json)
+        services = handler.get_services()
+        self.assertEqual(services, ["AmazonEC2", "AmazonS3"])
+
     def test_send_slack(self):
         url = "sample url"
         channel = "sample channel"


### PR DESCRIPTION
## Summary
- Add test for `get_services()` deduplication behavior
- Fix `get_services()` to deduplicate service names using `dict.fromkeys()`
- Prevents duplicate entries when AWS CloudWatch returns the same service in multiple dimension combinations (e.g. with `LinkedAccount`)

## Test plan
- [x] Test verifies duplicated services are deduplicated
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)